### PR TITLE
Remove internal message from output

### DIFF
--- a/ob-fsharp.el
+++ b/ob-fsharp.el
@@ -64,7 +64,7 @@
     (ob-fsharp--wait ob-fsharp-eoe)
     (string-trim
      (replace-regexp-in-string
-      (format "^> val it : string = \"%s\"\n> " ob-fsharp-eoe) "" ob-fsharp-process-output))))
+      (format "^> > val it : string = \"%s\"\n\n> " ob-fsharp-eoe) "" ob-fsharp-process-output))))
 
 
 (provide 'ob-fsharp)


### PR DESCRIPTION
Looks like the output format might have changed so it wouldn't be removed anymore.
This fix at least Works On My Machine ™