### PR TITLE
Development fix hang on fsharpi10

### DIFF
--- a/ob-fsharp.el
+++ b/ob-fsharp.el
@@ -65,7 +65,7 @@
     (ob-fsharp--wait ob-fsharp-eoe)
     (string-trim
      (replace-regexp-in-string
-      (format "^> val it : string = \"%s\"\n> " ob-fsharp-eoe) "" ob-fsharp-process-output))))
+      (format "^> val it : string = \"%s\"[^z-a]+> " ob-fsharp-eoe) "" ob-fsharp-process-output))))
 
 
 (provide 'ob-fsharp)

--- a/ob-fsharp.el
+++ b/ob-fsharp.el
@@ -60,6 +60,7 @@
   (let ((name (format "*ob-fsharp-%s*" session)))
     (setq ob-fsharp-process-output "")
     (process-send-string name (format "%s;;\n\"%s\";;\n" body ob-fsharp-eoe))
+    (process-send-eof name)
     (accept-process-output (get-process name) nil nil 1)
     (ob-fsharp--wait ob-fsharp-eoe)
     (string-trim


### PR DESCRIPTION
Hello.
Your version did not work anymore with a current fsharpi.  With this patch, it is now properly working under Arch (Emacs 27.1-2, fsharp 10.2.3-3, mono 6.10.0.104-1)